### PR TITLE
Add schema for oem-v151

### DIFF
--- a/static/metajsons/oemetdata_v151.json
+++ b/static/metajsons/oemetdata_v151.json
@@ -1,0 +1,681 @@
+{
+    "title": "OEM Creator - New metadata string using OEMetadata v1.5.1",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/master/oemetadata/v151/schema.json",
+    "description": "Open Energy Plaftorm (OEP) metadata schema latest",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "description": "Explanation of metadata keys in ontology terms. Example: https://raw.githubusercontent.com/LOD-GEOSS/databus-snippets/master/oep_metadata/context.jsonld",
+            "type": "string",
+            "format": "uri",
+            "title": "@context"
+        },
+        "name": {
+            "type": "string",
+            "description": "(e.g. oep_metadata_table_example_v150)",
+            "title": "Name"
+        },
+        "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "(e.g. Example title for metadata example - Version 1.5.0)"
+        },
+        "id": {
+            "description": "Uniform Resource Identifier (URI) that unambiguously identifies the resource. This can be a URL on the data set. It can also be a Digital Object Identifier (DOI). Example: https://example.com",
+            "type": "string",
+            "format": "uri",
+            "title": "Id"
+        },
+        "@id": {
+            "description": "Uniform Resource Identifier (URI) that links the resource via the databus",
+            "type": "string",
+            "format": "uri",
+            "title": "@Id"
+        },
+        "description": {
+            "description": "A description of the package. It should be usable as summary information for the entire package that is described by the metadata. Example: Example table used to illustrate the metadata structure and meaning",
+            "type": "string",
+            "title": "Description"
+        },
+        "subject": {
+            "description": "Reference the topic of the resource in ontology terms",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "Name of the OEO Class",
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "path": {
+                        "description": "Path to the OEO (URL)",
+                        "type": "string",
+                        "title": "Path",
+                        "format": "uri"
+                    }
+                },
+                "additionalProperties": false,
+                "title": "Subject"
+            },
+            "title": "Subject"
+        },
+        "language": {
+            "type": "array",
+            "items": {
+                "title": "language",
+                "type": "string",
+                "enum": [
+                    "en-GB",
+                    "en-US",
+                    "de-DE",
+                    "fr-FR"
+                ]
+            }
+        },
+        "keywords": {
+            "description": "An array of string keywords to assist users searching for the package in catalogs. Example: [example, template, test]",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "title": "Keyword"
+            },
+            "title": "Keyword"
+        },
+        "publicationDate": {
+            "description": "Date of publishing. Date Format is ISO 8601 (YYYY-MM-DD). Example: 2019-02-06",
+            "type": "string",
+            "title": "Publication date",
+            "format": "date"
+        },
+        "context": {
+            "description": "Object. Contains name-value-pairs that describe the general setting, evironment or project leading to the creation or maintenance of this dataset.",
+            "type": "object",
+            "properties": {
+                "homepage": {
+                    "description": "URL of project. Example: https://openenergy-platform.org/",
+                    "type": "string",
+                    "title": "Homepage",
+                    "format": "uri"
+                },
+                "documentation": {
+                    "description": "URL of project documentation. Example: https://github.com/OpenEnergyPlatform/metadata/wiki/Metadata-Description",
+                    "type": "string",
+                    "format": "uri",
+                    "title": "Documentation"
+                },
+                "sourceCode": {
+                    "description": "Url of project source code. Example: https://github.com/OpenEnergyPlatform",
+                    "type": "string",
+                    "format": "uri",
+                    "title": "Source code"
+                },
+                "contact": {
+                    "description": "Reference to the creator or maintainer of the data set. Example: contact@example.com",
+                    "type": "string",
+                    "title": "E-Mail contact",
+                    "format": "email"
+                },
+                "grantNo": {
+                    "description": "In a publicly funded Project: the identifying grant number. Example: 01AB2345",
+                    "type": "string",
+                    "title": "Grant no"
+                },
+                "fundingAgency": {
+                    "description": "In a funded Project: The name of the funding agency. Example: Bundesministerium für Wirtschaft und Energie",
+                    "type": "string",
+                    "title": "Funding agency"
+                },
+                "fundingAgencyLogo": {
+                    "description": "In a publicly funded Project: A link to the Logo of the funding agency. Example: https://www.innovation-beratung-foerderung.de/INNO/Redaktion/DE/Bilder/Titelbilder/titel_foerderlogo_bmwi.jpg?__blob=poster&v=2",
+                    "type": "string",
+                    "title": "Funding agency logo",
+                    "format": "uri"
+                },
+                "publisherLogo": {
+                    "description": "Link to the logo of the publishing institution. Example: https://reiner-lemoine-institut.de//wp-content/uploads/2015/09/rlilogo.png",
+                    "type": "string",
+                    "title": "Publisher logo",
+                    "format": "uri"
+                }
+            },
+            "additionalProperties": false,
+            "title": "Context"
+        },
+        "spatial": {
+            "description": "Object. Contains name-value-pairs describing the spatial context of the contained data.",
+            "type": "object",
+            "properties": {
+                "location": {
+                    "description": "In the case of data where the location can be described as a point. May come as coordinates, URI or addresses with street, house number and zip code. Example: 52.433509, 13.535855",
+                    "type": "string",
+                    "title": "Location"
+                },
+                "extent": {
+                    "description": "Covered area. May be the name of a region, or the geometry of a bounding box. Example: Europe",
+                    "type": "string",
+                    "title": "Extent"
+                },
+                "resolution": {
+                    "description": "Pixel size in case of a regular raster image. Reference to administrative level or other spatial division that is present as the smallest spatially distinguished unit size. Example: 30 m",
+                    "type": "string",
+                    "title": "Resolution"
+                }
+            },
+            "additionalProperties": false,
+            "title": "Spatial"
+        },
+        "temporal": {
+            "description": "Temporal object. Time period covered in the data. Temporal information should either contain a \"referenceDate\" or the keys describing a time series; in rare cases both. Use null for the ones that don't apply.",
+            "type": "object",
+            "properties": {
+                "referenceDate": {
+                    "description": "Base year, month or day. Point in time for which the data is meant to be accurate. A census will generally have a reference year. A satellite image will have a reference date. Date Format is ISO 8601. Example: 2016-01-01",
+                    "type": "string",
+                    "title": "Reference date",
+                    "format": "date"
+                },
+                "timeseries": {
+                    "description": "Times series object in temporal object, contains start, end, resolution, alignment and aggregation type properties.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "start": {
+                                "description": "The beginning point in time of a time series. Example: 2019-02-06T10:12:04+00:00",
+                                "type": "string",
+                                "title": "Start",
+                                "format": "date-time"
+                            },
+                            "end": {
+                                "description": "The end point in time of a time series. Example: 2019-02-07T10:12:04+00:00",
+                                "type": "string",
+                                "title": "End",
+                                "format": "date-time"
+                            },
+                            "resolution": {
+                                "description": "The time span between individual points of information in a time series. Example: 30 s",
+                                "type": "string",
+                                "title": "Resolution"
+                            },
+                            "alignment": {
+                                "description": "Indicator whether stamps in a time series are left, right or middle. \"null\" if there is no time series. Example: left",
+                                "type": "string",
+                                "title": "Alignment"
+                            },
+                            "aggregationType": {
+                                "description": "Indicates whether the values are a sum, average or current. Example: sum",
+                                "type": "string",
+                                "title": "Aggregation type"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "title": "Timeseries"
+                    },
+                    "title": "Timeseries"
+                }
+            },
+            "additionalProperties": false,
+            "title": "Temporal"
+        },
+        "sources": {
+            "description": "List of source objects. Each object has all name-value-pairs.",
+            "type": "array",
+            "items": {
+                "description": "Source object in list of source objects. Each object has all name-value-pairs.",
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "description": "Human readable title of the source, e.g. document title or organisation name. Example: IPCC Fifth Assessment Report",
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "description": {
+                        "description": "Free text description of the data set. Example: Scientific climate change report by the UN",
+                        "type": "string",
+                        "title": "Description"
+                    },
+                    "path": {
+                        "description": "URL to original source. Example: https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_full.pdf",
+                        "type": "string",
+                        "title": "Path",
+                        "format": "uri"
+                    },
+                    "licenses": {
+                        "description": "The license(s) under which the source(s) is/are provided. List of objects.",
+                        "type": "array",
+                        "items": {
+                            "description": "A license object under which the described source is provided. Each object has all name-value-pairs.",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "description": "SPDX identifier: Example: ODbL-1.0",
+                                    "type": "string",
+                                    "title": "Name"
+                                },
+                                "title": {
+                                    "description": "Official (human readable) title. Example: Open Data Commons Open Database License 1.0",
+                                    "type": "string",
+                                    "title": "Title"
+                                },
+                                "path": {
+                                    "description": "A link to the license. Example: https://opendatacommons.org/licenses/odbl/1-0/index.html",
+                                    "type": "string",
+                                    "title": "Path"
+                                },
+                                "instruction": {
+                                    "description": "Short description of rights and restrictions. Example: You are free to share and change, but you must attribute, and share derivations under the same license.",
+                                    "type": "string",
+                                    "title": "Instruction"
+                                },
+                                "attribution": {
+                                    "description": "Copyrightholder of the source. Example: © Intergovernmental Panel on Climate Change 2014",
+                                    "type": "string",
+                                    "title": "Attribution"
+                                }
+                            },
+                            "title": "Licenses"
+                        },
+                        "title": "Licenses"
+                    }
+                },
+                "additionalProperties": false,
+                "title": "Sources"
+            },
+            "title": "Sources"
+        },
+        "licenses": {
+            "description": "The license(s) under which the described package is provided. List of objects.",
+            "type": "array",
+            "items": {
+                "description": "A license object under which the described package is provided. Each object has all name-value-pairs.",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "SPDX identifier. Example: ODbL-1.0",
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "title": {
+                        "description": "Official (human readable) title. Example: Open Data Commons Open Database License 1.0",
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "path": {
+                        "description": "A url-or-path string, that is a fully qualified HTTP address, or a relative POSIX path (see the url-or-path definition in Data Resource for details). Example: https://opendatacommons.org/licenses/odbl/1-0/index.html",
+                        "type": "string",
+                        "title": "Path"
+                    },
+                    "instruction": {
+                        "description": "Short description of rights and restrictions. Example: You are free to share and change, but you must attribute, and share derivations under the same license.",
+                        "type": "string",
+                        "title": "Instruction"
+                    },
+                    "attribution": {
+                        "description": "Copyrightholder of the produced data set. Example: © Reiner Lemoine Institut",
+                        "type": "string",
+                        "title": "Attribution"
+                    }
+                },
+                "additionalProperties": false,
+                "title": "Licenses"
+            },
+            "title": "Licenses"
+        },
+        "contributors": {
+            "description": "The people or organizations who contributed to this data package. List of objects.",
+            "type": "array",
+            "items": {
+                "description": "A person or organizations who contributed to this data package. Each object refers to one contributor. Every contributor must have a title and property. A path, email, role and organization properties are optional extras.",
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "description": "Name/title of the contributor (name for a person, name or title for an organization). Example: Jon Doe",
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "email": {
+                        "description": "E-mail address of the contributor. Example: contact@example.com",
+                        "type": "string",
+                        "title": "Email",
+                        "format": "email"
+                    },
+                    "date": {
+                        "description": "Date of the contribution. If the contribution took more than a day, use the date of the final contribiution. Date Format is ISO 8601. Example: 2016-06-16",
+                        "type": "string",
+                        "title": "Date",
+                        "format": "date"
+                    },
+                    "object": {
+                        "description": "Target of contribution. Which part of the package was supplied/changed. Example: Metadata",
+                        "type": "string",
+                        "title": "Object"
+                    },
+                    "comment": {
+                        "description": "Free text comment on what's been done. Example: Fixed a typo in the title",
+                        "type": "string",
+                        "title": "Comment"
+                    }
+                },
+                "additionalProperties": false,
+                "title": "Contributors"
+            },
+            "title": "Contributors"
+        },
+        "resources": {
+            "description": "Resources, described as a list of data resource format objects.",
+            "type": "array",
+            "items": {
+                "description": "The data resource format describes a data resource as an individual file or table.",
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "description": "A string identifying the profile of this descriptor as per the profiles specification. This information is retained in order to comply with the \"Tabular Data Package\" standard. If at all in doubt the value should read \"tabular-data-resource\". Example: tabular-data-resource",
+                        "type": "string",
+                        "title": "Profile"
+                    },
+                    "name": {
+                        "description": "A resource MUST contain a name unique to amongst all resources in this data package. To comply with the data package standard it must consist of only lowercase alphanumeric character plus \".\", \"-\" and \"_\". It may not start with a number. In a database this will be the name of the table within its containing schema. It would be usual for the name to correspond to the file name (minus the file-extension) of the data file the resource describes. Example: sandbox.example_table",
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "path": {
+                        "description": "A url-or-path string, that should be a permanent http(s) address or other path directly linking to the resource. Example: directly linking to the resource. https://openenergy-platform.org/dataedit/view/openstreetmap/osm_deu_roads",
+                        "type": "string",
+                        "title": "Path"
+                    },
+                    "format": {
+                        "description": "\"csv\", \"xls\", \"json\" etc. would be expected to be the standard file extension for this type of resource. When you upload your data to the OEDB, in the shown metadata string, the format will be changed accordingly to \"PostgreSQL\", since the data there are stored in a database. Example: csv",
+                        "type": "string",
+                        "title": "Format"
+                    },
+                    "encoding": {
+                        "description": "Specifies the character encoding of the resource's data file. The values should be one of the \"Preferred MIME Names\" for a character encoding registered with IANA. If no value for this key is specified then the default is UTF-8. Example: UTF-8",
+                        "type": "string",
+                        "title": "Encoding"
+                    },
+                    "schema": {
+                        "description": "Object containing fields, primary key and for foreign keys. Describes the structure of the present data.",
+                        "type": "object",
+                        "properties": {
+                            "fields": {
+                                "description": "List of field objects.",
+                                "type": "array",
+                                "items": {
+                                    "description": "Field object. Every object describes a column and provides name, description, type and unit.",
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name string unique within its scope. Example: year",
+                                            "type": "string",
+                                            "title": "Name",
+                                            "readonly": true
+                                        },
+                                        "description": {
+                                            "description": "Free-text describing the field. Example: Reference year for which the data were collected.",
+                                            "type": "string",
+                                            "title": "Description"
+                                        },
+                                        "type": {
+                                            "description": "Data type of the field. In case of a geom-column in a database, also indicate the shape and CRS. Example: geometry(Point, 4326)",
+                                            "type": "string",
+                                            "title": "Type",
+                                            "readonly": true
+                                        },
+                                        "isAbout": {
+                                            "description": "Ontology URI to describe the column header",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name of the Dataset",
+                                                        "type": "string",
+                                                        "title": "Name"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to the OEO (URL)",
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "format": "uri"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "title": "IsAbout"
+                                            },
+                                            "title": "IsAbout"
+                                        },
+                                        "valueReference": {
+                                            "description": "Ontology URI for an extended description of the values in the column",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "value": {
+                                                        "description": "The value this reference is assinged to.",
+                                                        "type": "string",
+                                                        "title": "Value"
+                                                    },
+                                                    "name": {
+                                                        "description": "Full name of the value",
+                                                        "type": "string",
+                                                        "title": "Name",
+                                                        "format": "uri"
+                                                    },
+                                                    "path": {
+                                                        "description": "Path to the OEO",
+                                                        "type": "string",
+                                                        "title": "Path",
+                                                        "format": "uri"
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "title": "Value reference"
+                                            },
+                                            "title": "valueReference"
+                                        },
+                                        "unit": {
+                                            "description": "Unit, preferably SI-Unit, that values in this field are mapped to. If \"unit\" doesn't apply to a field, use \"null\". Example: MW",
+                                            "type": "string",
+                                            "title": "Unit"
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "title": "Field"
+                                },
+                                "title": "Field"
+                            },
+                            "primaryKey": {
+                                "description": "A primary key is a field or set of fields that uniquely identifies each row in the table. It's recorded as a list of strings, since it is possible to define the primary key as made up of several columns. Example: id",
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "title": "Primary key"
+                                },
+                                "title": "Primary key"
+                            },
+                            "foreignKeys": {
+                                "description": "List of foreign keys.",
+                                "type": "array",
+                                "items": {
+                                    "description": "A foreign key is a field that refers to a column in another table.",
+                                    "type": "object",
+                                    "properties": {
+                                        "fields": {
+                                            "description": "The column (as list of items) in the table that is constrainted by the foreign key. Example: version",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "title": "Field"
+                                            },
+                                            "title": "Fields"
+                                        },
+                                        "reference": {
+                                            "description": "The reference to the foreign table.",
+                                            "type": "object",
+                                            "properties": {
+                                                "resource": {
+                                                    "description": "The foreign resource (table). Example: schema.table",
+                                                    "type": "string",
+                                                    "title": "Resource"
+                                                },
+                                                "fields": {
+                                                    "description": "The foreign resource column. List of fields. Example: version",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "title": "Field"
+                                                    },
+                                                    "title": "Field"
+                                                }
+                                            },
+                                            "additionalProperties": false,
+                                            "title": "Reference"
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "title": "Foreign Key"
+                                },
+                                "title": "Foreign Keys"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "title": "Schema"
+                    },
+                    "dialect": {
+                        "description": "Object. A CSV Dialect defines a simple format to describe the various dialects of CSV files in a language agnostic manner. In case of a database, the values in the containing fields are \"null\".",
+                        "type": "object",
+                        "properties": {
+                            "delimiter": {
+                                "description": "Specifies the character sequence which should separate fields (aka columns). Common characters are \",\" (comma), \".\" (point) and \"\t\" (tab). Example: ,",
+                                "type": "string",
+                                "title": "Delimiter"
+                            },
+                            "decimalSeparator": {
+                                "description": "Symbol used to separate the integer part from the fractional part of a number written in decimal form. Depending on language and region this symbol can be \".\" or \",\". Example: .",
+                                "type": "string",
+                                "title": "Decimal separator"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "title": "Dialect"
+                    }
+                },
+                "additionalProperties": false,
+                "title": "Resource"
+            },
+            "title": "Resource"
+        },
+        "review": {
+            "description": "Data uploaded through the OEP needs to go through review. The review will cover the areas described here: https://github.com/OpenEnergyPlatform/data-preprocessing/wiki and carried out by a team of the platform. The review itself is documented at the specified path and a badge is rewarded with regards to completeness.",
+            "type": "object",
+            "properties": {
+                "path": {
+                    "description": "A URL or path string, that should be a permanent http(s) address directly linking to the documented review. Example: https://www.example.com",
+                    "type": "string",
+                    "title": "Path"
+                },
+                "badge": {
+                    "description": "A badge of either Bronze, Silver, Gold or Platin is used to label the given metadata based on its quality. Example: Platin",
+                    "type": "string",
+                    "title": "Badge"
+                }
+            },
+            "additionalProperties": false,
+            "title": "Review"
+        },
+        "metaMetadata": {
+            "description": "Object. Description about the metadata themselves, their format, version and license. These fields should already be provided when you’re filling out your metadata.",
+            "type": "object",
+            "properties": {
+                "metadataVersion": {
+                    "description": "Type and version number of the metadata. Example: OEP-1.5",
+                    "type": "string",
+                    "title": "Metadata version"
+                },
+                "metadataLicense": {
+                    "description": "Object describing the license of the provided metadata.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "SPDX identifier. Example: CC0-1.0",
+                            "type": "string",
+                            "title": "Name"
+                        },
+                        "title": {
+                            "description": "Official (human readable) license title. Example: Creative Commons Zero v1.0 Universal",
+                            "type": "string",
+                            "title": "Title"
+                        },
+                        "path": {
+                            "description": "Url or path string, that is a fully qualified HTTP address. Example: https://creativecommons.org/publicdomain/zero/1.0/",
+                            "type": "string",
+                            "title": "Path"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "title": "Metadata license"
+                }
+            },
+            "additionalProperties": false,
+            "title": "Meta metadata",
+            "options": {
+                "disable_edit_json": "True",
+                "hidden": "True"
+            }
+        },
+        "_comment": {
+            "description": "Object. The “_comment”-section is used as a self-description of the final metadata-file. It is text, intended for humans and can include a link to the metadata documentation(s), required value formats and similar remarks. The comment section has no fix structure or mandatory values, but a useful self-description, similar to the one depicted here, is encouraged.",
+            "type": "object",
+            "options": {
+                "disable_edit_json": "True",
+                "hidden": "True"
+            },
+            "properties": {
+                "metadata": {
+                    "description": "Reference to the metadata documentation in use. Example: Metadata documentation and explanation (https://github.com/OpenEnergyPlatform/organisation/wiki/metadata)",
+                    "type": "string",
+                    "title": "Metadata"
+                },
+                "dates": {
+                    "description": "Comment on data/time format. Example: Dates and time must follow the ISO8601 including time zone (YYYY-MM-DD or YYYY-MM-DDThh:mm:ss±hh)",
+                    "type": "string",
+                    "title": "Dates"
+                },
+                "units": {
+                    "description": "Comment on units. Example: If you must use units in cells (which is discouraged), leave a space between numbers and units (100 m)",
+                    "type": "string",
+                    "title": "Units"
+                },
+                "languages": {
+                    "description": "Comment on language format. Example: Languages must follow the IETF (BCP47) format (en-GB, en-US, de-DE)",
+                    "type": "string",
+                    "title": "Languages"
+                },
+                "licenses": {
+                    "description": "Reference to license format. Example: License name must follow the SPDX License List (https://spdx.org/licenses/)",
+                    "type": "string",
+                    "title": "Licenses"
+                },
+                "review": {
+                    "description": "Reference to review documentation. Example: Following the OEP Data Review (https://github.com/OpenEnergyPlatform/data-preprocessing/wiki)",
+                    "type": "string",
+                    "title": "Review"
+                },
+                "null": {
+                    "description": "Feel free to add more descriptive comments. Like \"null\". Example: If a field is not applicable just enter \"null\"",
+                    "type": "string",
+                    "title": "Null"
+                },
+                "todo": {
+                    "description": "If an applicable value is not yet available and will be inserted later on use: 'todo' ",
+                    "type": "string",
+                    "title": "Todo"
+                }
+            },
+            "title": "_comment"
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
The schema.json for oem version 1.5.1 was created from the schema.json in the oemetadata repository and added to the meta_tool. Please test!

My plan is to add the schema.json to the oemetadata repository and develop it there for each new version. A tool like the meta tool then can import the schema as python module from the pip package oep-metadata. 

Basically there is already a schema.json in the oemetadata repository, but null types are used there, which are important for JSON validation (CI). So another schema_without_null_types.json must be added.
